### PR TITLE
NFC: Add HCE declaration

### DIFF
--- a/device.mk
+++ b/device.mk
@@ -26,7 +26,8 @@ PRODUCT_PROPERTY_OVERRIDES += \
 	ro.telephony.default_network=9
 
 PRODUCT_COPY_FILES += \
-	frameworks/native/data/etc/android.hardware.telephony.gsm.xml:system/etc/permissions/android.hardware.telephony.gsm.xml
+	frameworks/native/data/etc/android.hardware.telephony.gsm.xml:system/etc/permissions/android.hardware.telephony.gsm.xml \
+	frameworks/native/data/etc/android.hardware.nfc.hce.xml:system/etc/permissions/android.hardware.nfc.hce.xml
 
 # NFC packages
 PRODUCT_PACKAGES += \


### PR DESCRIPTION
Removed from common due to the existence of pn544 variants. d802 has an
NCI-compliant bcm

Change-Id: I4393c2c0d32a105f6686fd9f6b056c98e455ab87